### PR TITLE
Feature: load / save max fps value in config

### DIFF
--- a/src/core/re3.cpp
+++ b/src/core/re3.cpp
@@ -516,6 +516,7 @@ bool LoadINISettings()
 	ReadIniIfExists("Display", "Subtitles", &FrontEndMenuManager.m_PrefsShowSubtitles);
 	ReadIniIfExists("Graphics", "AspectRatio", &FrontEndMenuManager.m_PrefsUseWideScreen);
 	ReadIniIfExists("Graphics", "FrameLimiter", &FrontEndMenuManager.m_PrefsFrameLimiter);
+	ReadIniIfExists("Graphics", "MaxFPS", &RsGlobal.maxFPS);
 #ifdef LEGACY_MENU_OPTIONS
 	ReadIniIfExists("Graphics", "VSync", &FrontEndMenuManager.m_PrefsVsyncDisp);
 	ReadIniIfExists("Graphics", "Trails", &CMBlur::BlurOn);
@@ -635,6 +636,7 @@ void SaveINISettings()
 	StoreIni("Display", "ShowHud", FrontEndMenuManager.m_PrefsShowHud);
 	StoreIni("Display", "RadarMode", FrontEndMenuManager.m_PrefsRadarMode);
 	StoreIni("Display", "ShowLegends", FrontEndMenuManager.m_PrefsShowLegends);
+	StoreIni("Graphics", "MaxFPS", RsGlobal.maxFPS);
 
 #ifdef EXTENDED_COLOURFILTER
 	StoreIni("CustomPipesValues", "PostFXIntensity", CPostFX::Intensity);


### PR DESCRIPTION
Hi, @AltronMaxX.

Until a solution is found to the physics bugs at high FPS, I suggest the following partial workaround. I found a commit that implemented the reading of the maximum frame rate parameter and its subsequent writing to the configuration file. This way, users will be able to raise the FPS limit to a level where physics distortions are minimal, whilst still achieving a smooth display.

I am not the author of the commit. Here is the [link](https://github.com/ibnfzy/reVC/commit/1f90c7a89415287be21ae776aa88710f1a53cd68) to the commit.



I propose merging this feature into the main branch, as I consider this change to be important.



Together, we can make the reVC engine even better!

<img width="1920" height="1200" alt="Знімок екрана з 2026-07-21 21-13-47" src="https://github.com/user-attachments/assets/74e56a47-4bed-42eb-a051-69f0a7418f98" />

<img width="956" height="1151" alt="Знімок екрана з 2026-07-21 21-16-17" src="https://github.com/user-attachments/assets/eba57488-bb77-45d7-ae52-1851a930d161" />


